### PR TITLE
upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,44 @@
-FROM python:3.7.1-alpine3.8
+FROM python:3.7.2-alpine3.7
 
-ENV PYTEST_BDD_VERSION 2.21.0
+ENV PYTEST_BDD_VERSION 3.0.1
 
 RUN apk --no-cache --update add openssl libffi
 RUN apk --no-cache --update add --virtual build-dependencies build-base libffi-dev openssl-dev \
  && pty=False pip install \
-    certifi==2018.8.24 \
+    asn1crypto==0.24.0 \
+    atomicwrites==1.2.1 \
+    attrs==18.2.0 \
+    bravado-core==5.10.1 \
+    certifi==2018.11.29 \
+    cffi==1.11.5 \
     chardet==3.0.4 \
+    cryptography==2.5 \
     glob2==0.6 \
-    idna==2.7 \
+    idna==2.8 \
+    jsonref==0.2 \
+    jsonschema==2.6.0 \
     Mako==1.0.7 \
-    MarkupSafe==1.0 \
-    parse==1.8.4 \
+    MarkupSafe==1.1.0 \
+    more-itertools==5.0.0 \
+    msgpack-python==0.5.6 \
+    parse==1.11.1 \
     parse-type==0.4.2 \
-    py==1.6.0 \
-    pytest==3.7.4 \
+    pluggy==0.8.1 \
+    py==1.7.0 \
+    pycodestyle==2.4.0 \
+    pycparser==2.19 \
+    PyJWT==1.7.1 \
+    pytest==3.10.1 \
     pytest-bdd==$PYTEST_BDD_VERSION \
-    requests==2.19.1 \
-    six==1.11.0 \
-    urllib3==1.23 \
+    python-dateutil==2.7.5 \
+    pytz==2018.9 \
     PyYAML==3.13 \
-    bravado_core==5.0.7 \
-    PyJWT==1.6.4 \
-    cryptography==2.3.1 \
-    pycodestyle==2.4.0 \
+    requests==2.21.0 \
+    rfc3987==1.3.8 \
+    simplejson==3.16.0 \
+    six==1.12.0 \
+    strict-rfc3339==0.7 \
+    swagger-spec-validator==2.4.3 \
+    urllib3==1.24.1 \
+    webcolors==1.8.1 \
   && apk del build-dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+TAG ?= frodeaa/docker-pytest-bdd
+
+build:
+	@docker build -t $(TAG) .
+
+test:
+	@docker run \
+	-v $(CURDIR)/example:/example \
+	-w /example $(TAG) \
+	pytest -vv --gherkin-terminal-reporter
+
+install: build test


### PR DESCRIPTION
update dependencies and upgrade to python 3.7

 - pytest-bdd 2.21.0 => 3.0.1
 - bravado_core 5.0.6 => 5.10.1

Note: pytest not updated to latest > 4.0 as
RemovedInPytest4Warnings are there error by default
something that will break tests