### PR TITLE
SEC: upgrade urllib3 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ COPY requirements.txt .
 
 RUN apk --no-cache --update add openssl libffi
 RUN apk --no-cache --update add --virtual build-dependencies build-base libffi-dev openssl-dev \
-  && pty=False pip3 install -r requirements.txt \
+  && pty=False pip3 install --disable-pip-version-check -r requirements.txt \
   && apk del build-dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,12 +27,12 @@ pytest-bdd==3.1.0
 python-dateutil==2.7.5
 pytz==2018.9
 PyYAML==5.1
-requests==2.21.0
+requests==2.22.0
 rfc3987==1.3.8
 simplejson==3.16.0
 six==1.12.0
 strict-rfc3339==0.7
 swagger-spec-validator==2.4.3
-urllib3==1.24.1
+urllib3==1.25.2
 wcwidth==0.1.7
 webcolors==1.8.1


### PR DESCRIPTION
[CVE-2019-11324] is fixed in urllib3>=1.24.2

 - urllib3  1.24.1 => 1.25.2
 - requests 2.21.0 => 2.22.0

request upgraded to fix warnings about required
urllib3 version

CVE-2019-11324: https://nvd.nist.gov/vuln/detail/CVE-2019-11324