### PR TITLE
Fix conflicting dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 asn1crypto==1.3.0
 atomicwrites==1.3.0
 attrs==19.3.0
-awscli==1.17.9
-boto3==1.11.9
-botocore==1.14.9
+awscli==1.20.63
+boto3==1.18.63
+botocore==1.21.63
 bravado-core==5.16.0
 certifi==2019.11.28
 cffi==1.13.2
@@ -38,10 +38,10 @@ pytest-parallel==0.1.0
 python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.4
-requests==2.22.0
+requests==2.26.0
 rfc3987==1.3.8
 rsa==4.7
-s3transfer==0.3.2
+s3transfer==0.5.0
 simplejson==3.17.0
 six==1.14.0
 strict-rfc3339==0.7


### PR DESCRIPTION
Bump dependencies to resolve the conflicts with rsa/awscli and
urllib3/botocore/requests

- awscli from 1.17.9 to 1.20.63
- boto3 from 1.11.9 to 1.18.63
- botocore from 1.14.9 to 1.21.63
- requests from 2.22.0 to 2.26.0
- s3transfer from 0.3.2 to 0.5.0

Blame: https://github.com/frodeaa/docker-pytest-bdd/pull/17
Blame: https://github.com/frodeaa/docker-pytest-bdd/pull/18
